### PR TITLE
Fix special character handling via PDO parameterized bindings

### DIFF
--- a/src/Traits/Encryptable.php
+++ b/src/Traits/Encryptable.php
@@ -48,8 +48,9 @@ trait Encryptable
      */
     public function scopeWhereEncrypted($query, $column, $value)
     {
+        [$sql, $bindings] = db_decrypt_string($column, $value);
         /** @var Builder $query */
-        return $query->whereRaw(db_decrypt_string($column, $value));
+        return $query->whereRaw($sql, $bindings);
     }
 
     /**
@@ -63,8 +64,9 @@ trait Encryptable
      */
     public function scopeWhereNotEncrypted($query, $column, $value)
     {
+        [$sql, $bindings] = db_decrypt_string($column, $value, '!=');
         /** @var Builder $query */
-        return $query->whereRaw(db_decrypt_string($column, $value, 'NOT LIKE'));
+        return $query->whereRaw($sql, $bindings);
     }
 
     /**
@@ -78,8 +80,9 @@ trait Encryptable
      */
     public function scopeOrWhereEncrypted($query, $column, $value)
     {
+        [$sql, $bindings] = db_decrypt_string($column, $value);
         /** @var Builder $query */
-        return $query->orWhereRaw(db_decrypt_string($column, $value));
+        return $query->orWhereRaw($sql, $bindings);
     }
 
     /**
@@ -93,8 +96,9 @@ trait Encryptable
      */
     public function scopeOrWhereNotEncrypted($query, $column, $value)
     {
+        [$sql, $bindings] = db_decrypt_string($column, $value, '!=');
         /** @var Builder $query */
-        return $query->orWhereRaw(db_decrypt_string($column, $value, 'NOT LIKE'));
+        return $query->orWhereRaw($sql, $bindings);
     }
 
     /**
@@ -109,7 +113,7 @@ trait Encryptable
     public function scopeOrderByEncrypted($query, $column, $direction)
     {
         /** @var Builder $query */
-        return $query->orderByRaw(db_decrypt_string($column, $direction, ''));
+        return $query->orderByRaw(db_decrypt_string_sort($column, $direction));
     }
 
 
@@ -124,8 +128,9 @@ trait Encryptable
      */
     public function scopeWhereEncryptedLike($query, $column, $value)
     {
+        [$sql, $bindings] = db_decrypt_string_like($column, $value);
         /** @var Builder $query */
-        return $query->whereRaw(db_decrypt_string_like($column, $value));
+        return $query->whereRaw($sql, $bindings);
     }
 
 
@@ -140,8 +145,9 @@ trait Encryptable
      */
     public function scopeOrWhereEncryptedLike($query, $column, $value)
     {
+        [$sql, $bindings] = db_decrypt_string_like($column, $value);
         /** @var Builder $query */
-        return $query->orWhereRaw(db_decrypt_string_like($column, $value));
+        return $query->orWhereRaw($sql, $bindings);
     }
 
     /**

--- a/tests/Unit/DatabaseTest.php
+++ b/tests/Unit/DatabaseTest.php
@@ -20,12 +20,19 @@ beforeEach(function () {
     Testing::create(['value' => 'testing string']);
     Testing::create(['value' => 'hello world']);
     Testing::create(['value' => "it's me"]);
+    Testing::create(['value' => "O'Brien"]);
+    Testing::create(['value' => 'say "hello"']);
+    Testing::create(['value' => 'back\\slash']);
+    Testing::create(['value' => '100%_done']);
+    Testing::create(['value' => 'emoji 😀🎉']);
+    Testing::create(['value' => 'price^100']);
+    Testing::create(['value' => 'Tomáš']);
 });
 
 it('saves encrypted value to database', function () {
     $data = Testing::all()->toArray();
 
-    expect(count($data))->toBe(3);
+    expect(count($data))->toBe(10);
     expect($data[0]['value'])->toBe('testing string');
     expect($data[1]['value'])->toBe('hello world');
 });
@@ -40,7 +47,7 @@ it('can match Sql syntex', function () {
 });
 
 it('can search encrypted data', function () {
-    $this->assertCount(1, Testing::query()->whereEncryptedLike('value', 'hello')->get());
+    $this->assertCount(2, Testing::query()->whereEncryptedLike('value', 'hello')->get());
 });
 
 it('can search OrWhereEncryptedLike', function () {
@@ -50,4 +57,66 @@ it('can search OrWhereEncryptedLike', function () {
             ->orWhereEncryptedLike('value', 'world')
             ->get()
     );
+});
+
+it('handles single quotes in encrypted data', function () {
+    $result = Testing::query()->whereEncrypted('value', "O'Brien")->get();
+    $this->assertCount(1, $result);
+    expect($result->first()->value)->toBe("O'Brien");
+});
+
+it('handles double quotes in encrypted data', function () {
+    $result = Testing::query()->whereEncrypted('value', 'say "hello"')->get();
+    $this->assertCount(1, $result);
+    expect($result->first()->value)->toBe('say "hello"');
+});
+
+it('handles backslashes in encrypted data', function () {
+    $result = Testing::query()->whereEncrypted('value', 'back\\slash')->get();
+    $this->assertCount(1, $result);
+    expect($result->first()->value)->toBe('back\\slash');
+});
+
+it('handles LIKE wildcards in exact match', function () {
+    $result = Testing::query()->whereEncrypted('value', '100%_done')->get();
+    $this->assertCount(1, $result);
+    expect($result->first()->value)->toBe('100%_done');
+});
+
+it('handles emoji and multibyte in encrypted data', function () {
+    $result = Testing::query()->whereEncrypted('value', 'emoji 😀🎉')->get();
+    $this->assertCount(1, $result);
+    expect($result->first()->value)->toBe('emoji 😀🎉');
+});
+
+it('handles LIKE search with special characters', function () {
+    // Searching for "%" should match the row containing 100%_done but not others
+    $result = Testing::query()->whereEncryptedLike('value', '100%')->get();
+    $this->assertCount(1, $result);
+    expect($result->first()->value)->toBe('100%_done');
+});
+
+it('handles caret in encrypted data', function () {
+    $result = Testing::query()->whereEncrypted('value', 'price^100')->get();
+    $this->assertCount(1, $result);
+    expect($result->first()->value)->toBe('price^100');
+});
+
+it('handles diacritics in encrypted data', function () {
+    $result = Testing::query()->whereEncrypted('value', 'Tomáš')->get();
+    $this->assertCount(1, $result);
+    expect($result->first()->value)->toBe('Tomáš');
+});
+
+it('retrieves all special character values correctly', function () {
+    $data = Testing::all();
+    $values = $data->pluck('value')->toArray();
+
+    expect($values)->toContain("O'Brien");
+    expect($values)->toContain('say "hello"');
+    expect($values)->toContain('back\\slash');
+    expect($values)->toContain('100%_done');
+    expect($values)->toContain('emoji 😀🎉');
+    expect($values)->toContain('price^100');
+    expect($values)->toContain('Tomáš');
 });


### PR DESCRIPTION
## Summary
- Replaced `addslashes()` and raw string concatenation with `DB::getPdo()->quote()` and PDO parameterized bindings across all helper functions, query scopes, and validators
- Fixes SQL breakage for values containing single quotes, double quotes, backslashes, LIKE wildcards (`%`, `_`), and multibyte/emoji characters
- Eliminates SQL injection risks in encrypted column queries and validation rules

## Test plan
- [x] All 14 tests pass (5 existing + 9 new special character tests)
- [ ] Verify encrypted CRUD with special characters (quotes, backslashes, wildcards, emoji, diacritics, caret)
- [ ] Verify `whereEncrypted`, `whereEncryptedLike`, `orWhereEncryptedLike` scopes with special character values
- [ ] Verify `unique_encrypted` and `exists_encrypted` validators with special character values